### PR TITLE
Show numberpad in textfield

### DIFF
--- a/ResSet16/ContentView.swift
+++ b/ResSet16/ContentView.swift
@@ -23,8 +23,10 @@ struct ContentView: View {
                 VStack {
                     TextField("New height", value: $height, format: .number)
                         .textFieldStyle(.roundedBorder)
+                        .keyboardType(.decimalPad)
                     TextField("New width", value: $width, format: .number)
                         .textFieldStyle(.roundedBorder)
+                        .keyboardType(.decimalPad)
                 }
                 .padding()
                 .frame(maxWidth: 350)


### PR DESCRIPTION
A full-size keyboard just doesn't make sense in this context.